### PR TITLE
Handle scenario when tags are not available in aws

### DIFF
--- a/templates/consul.conf.erb
+++ b/templates/consul.conf.erb
@@ -21,7 +21,27 @@ pre-start script
 
     URL="http://169.254.169.254/latest/"
     ID=$(curl -s $URL/meta-data/instance-id)
-    STACK_ID=$(aws --region ${EC2_REGION} ec2 describe-tags --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+    echo "Instance ID : ${ID}"
+
+    EC2_AVAIL_ZONE=`curl -s $URL/meta-data/placement/availability-zone`
+    EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
+    echo "EC2_AVAIL_ZONE : ${EC2_AVAIL_ZONE}"
+    echo "EC2_REGION : ${EC2_REGION}"
+
+    STACK_ID=$(aws ec2 describe-tags --region ${EC2_REGION} --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+
+    # Tags may not be available for use with newly launched instances. Eventhough its rare, it happens.
+    # We have seen it 1 out of 6 times. Make sure we got stack id.
+
+    echo "Check and wait while we have STACK_ID from AWS instance tags"
+    while [ -z $STACK_ID ]; do
+      echo -n "."
+      sleep 1
+      STACK_ID=$(aws ec2 describe-tags --region ${EC2_REGION} --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+    done
+    echo '*'
+    echo "Stack ID : ${STACK_ID}"
+
     SERVERS=$(aws --region ${EC2_REGION} ec2 describe-instances --filters "Name=tag:Name,Values=${CLOUD_ENVIRONMENT}" "Name=tag:aws:cloudformation:logical-id,Values=ConsulAutoScalingGroup" | jq -r '.Reservations[].Instances[].PrivateIpAddress | select(. !=null)')
     BOOTSTRAP_EXPECT=$(cat <%= @config_dir %>/configuration.json | jq -r '.bootstrap_expect')
 
@@ -40,7 +60,27 @@ script
 
     URL="http://169.254.169.254/latest/"
     ID=$(curl -s $URL/meta-data/instance-id)
-    STACK_ID=$(aws --region ${EC2_REGION} ec2 describe-tags --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+    echo "Instance ID : ${ID}"
+
+    EC2_AVAIL_ZONE=`curl -s $URL/meta-data/placement/availability-zone`
+    EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
+    echo "EC2_AVAIL_ZONE : ${EC2_AVAIL_ZONE}"
+    echo "EC2_REGION : ${EC2_REGION}"
+
+    STACK_ID=$(aws ec2 describe-tags --region ${EC2_REGION} --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+
+    # Tags may not be available for use with newly launched instances. Eventhough its rare, it happens.
+    # We have seen it 1 out of 6 times. Make sure we got stack id.
+
+    echo "Check and wait while we have STACK_ID from AWS instance tags"
+    while [ -z $STACK_ID ]; do
+      echo -n "."
+      sleep 1
+      STACK_ID=$(aws ec2 describe-tags --region ${EC2_REGION} --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+    done
+    echo '*'
+    echo "Stack ID : ${STACK_ID}"
+
     SERVERS=$(aws --region ${EC2_REGION} ec2 describe-instances --filters "Name=tag:Name,Values=${CLOUD_ENVIRONMENT}" "Name=tag:aws:cloudformation:logical-id,Values=ConsulAutoScalingGroup" | jq -r '.Reservations[].Instances[].PrivateIpAddress  | select(. !=null)')
     BOOTSTRAP_EXPECT=$(cat <%= @config_dir %>/configuration.json | jq -r '.bootstrap_expect')
 
@@ -69,7 +109,26 @@ post-start script
 
         URL="http://169.254.169.254/latest/"
         ID=$(curl -s $URL/meta-data/instance-id)
+        echo "Instance ID : ${ID}"
+
+        EC2_AVAIL_ZONE=`curl -s $URL/meta-data/placement/availability-zone`
+        EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
+        echo "EC2_AVAIL_ZONE : ${EC2_AVAIL_ZONE}"
+        echo "EC2_REGION : ${EC2_REGION}"
+
         STACK_ID=$(aws ec2 describe-tags --region ${EC2_REGION} --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+
+        # Tags may not be available for use with newly launched instances. Eventhough its rare, it happens.
+        # We have seen it 1 out of 6 times. Make sure we got stack id.
+
+        echo "Check and wait while we have STACK_ID from AWS instance tags"
+        while [ -z $STACK_ID ]; do
+          echo -n "."
+          sleep 1
+          STACK_ID=$(aws ec2 describe-tags --region ${EC2_REGION} --filter Name=resource-id,Values=${ID} | jq -r .Tags | jq '.[] | select(.Key=="aws:cloudformation:stack-id")' | jq ".Value")
+        done
+        echo '*'
+        echo "Stack ID : ${STACK_ID}"
 
         # Get the ip address of self
         IP=$(ip addr show dev eth0|awk '/inet /{print $2}'|cut -d/ -f1)


### PR DESCRIPTION
Tags may not be available for use with newly launched instances. Even though its rare, it happens. Adding retry.